### PR TITLE
Fix typo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ And two things snakebasket **doesn't** (but pip does):
 
 git and PyPI packages only at this point.
 
-## How do we use snakebaset at Prezi?
+## How do we use snakebasket at Prezi?
 
 Many of our projects have dependency hierarchies multiple layers deep. When we want to install one for development or a production build, we simply run `sb install -r requirements.txt` from the project's root, and all packages in the hierarchy are installed in minutes.
 


### PR DESCRIPTION
Fixed typo.

You might be wondering what a "snakebaset" is, and at first I did as well, but then I decided it must be a kind of reptilian companion to [Baset](http://en.wikipedia.org/wiki/Bastet), a female cat goddess.

After being incredibly entertained by Wikipedia in a path that ultimately brought me [back to Philosophy](http://flowingdata.com/2011/06/08/all-roads-lead-to-philosophy-on-wikipedia/), I realized it likely had a much simpler explanation:

It should be **snakebasket**.
